### PR TITLE
Update readme. Add auto create dataset if it does not exist.

### DIFF
--- a/services/analytics/.gitignore
+++ b/services/analytics/.gitignore
@@ -1,0 +1,2 @@
+# cred file
+credentials.json

--- a/services/analytics/README.md
+++ b/services/analytics/README.md
@@ -22,11 +22,13 @@ You need to get a JSON key file with access to BigQuery.
 
 1. Go to the Google APIs [Credentials console](https://console.developers.google.com/projectselector/apis/credentials). Select your project.
 
-2. Click `Create Credentials` and choose `Service account key`.
+1. Go to the [Google APIs Library](https://console.developers.google.com/apis/library) page, and click on the [BiqQuery API](https://console.developers.google.com/apis/api/bigquery-json.googleapis.com/overview) link to make sure the API is enabled for your project.
 
-3. In the Service Account dropdown, choose `New service account`. Give it a name. In the Role box, go to BigQuery and select BigQuery Admin.
+1. Click `Create Credentials` and choose `Service account key`.
 
-4. Use a JSON key type and hit 'Create'. It will download a JSON file to your computer. Move it to this directory as the file name `credentials.json`. 
+1. In the Service Account dropdown, choose `New service account`. Give it a name. In the Role box, go to BigQuery and select BigQuery Admin.
+
+1. Use a JSON key type and hit 'Create'. It will download a JSON file to your computer. Move it to this directory as the file name `credentials.json`. 
 
 ## Using BigQuery
 

--- a/services/analytics/setup.js
+++ b/services/analytics/setup.js
@@ -15,31 +15,32 @@ const bigquery = BigQuery({
 
 const dataset = bigquery.dataset(DATASET_ID);
 const opts = {
-  schema: 'event:string,id:string,receivedAt:timestamp,data:string'
+  schema: 'event:string,id:string,receivedAt:timestamp,data:string',
+  autoCreate: true
 }
 
-dataset.create(function(err, dataset, apiResponse) {
+// Get a dataset if it exists or create it if it doesn't
+dataset.get(opts, function(err, dataset, apiResponse) {
   if (err) {
-    if (err.errors.length === 1 && err.errors[0].reason == 'duplicate') {
-      console.log('Dataset ' + DATASET_ID + ' already exists.');
-    } else {
-      console.log('Error creating dataset');
-      throw new Error(err);
-    }
+    console.log('Error creating dataset');
+    throw new Error(err);
   } else {
     console.log('Dataset ' + DATASET_ID + ' created successfully.');
+
+    // make sure to call createTable only on success
+    dataset.createTable(TABLE_ID, opts, function(err, table, apiResponse) {
+      if (err) {
+        if (err.errors.length === 1 && err.errors[0].reason == 'duplicate') {
+          console.log('Table ' + TABLE_ID + ' already exists.');
+        } else {
+          console.log('Error creating table');
+          throw new Error(err);
+        }
+      } else {
+        console.log('Table ' + TABLE_ID + ' created successfully.');
+      }
+    })
+        
   }
 })
 
-dataset.createTable(TABLE_ID, opts, function(err, table, apiResponse) {
-  if (err) {
-    if (err.errors.length === 1 && err.errors[0].reason == 'duplicate') {
-      console.log('Table ' + TABLE_ID + ' already exists.');
-    } else {
-      console.log('Error creating table');
-      throw new Error(err);
-    }
-  } else {
-    console.log('Table ' + TABLE_ID + ' created successfully.');
-  }
-})


### PR DESCRIPTION
- Used `dataset.get()`, which auto creates the dataset if it does not exist. Removed error checking for duplicate, as that error is never thrown. But leaving in an error check, just in case some other error happens.
- Nested the `dataset.createTable()` inside `dataset.get()` success path. I noticed that if you delete the dataset and then immediately run the setup code, the setup fails.  Due to async nature of the code, the `dataset.createTable()` gets called and fails. Nesting it inside prevents that.

/cc @alexdebrie 